### PR TITLE
events: use coordinates to display map

### DIFF
--- a/app/views/events/_attrs_primary.html.haml
+++ b/app/views/events/_attrs_primary.html.haml
@@ -31,10 +31,10 @@
 
   - unless entry.is_a?(Event::Camp) && !can?(:show_details, entry)
     = render_present_attrs(entry, :location)
-    - if entry.location.present?
+    - if entry.location.present? or entry.coordinates.present?
       %dl.dl-horizontal.dl-borderless
         %dd
-          %iframe{ name: 'map', src: "https://map.geo.admin.ch/embed.html?swisssearch=#{entry.location.gsub(/\n/, ', ')} limit:1", width: '100%', height: '300' }
+          %iframe{ name: 'map', src: "https://map.geo.admin.ch/embed.html?swisssearch=#{URI::encode(entry.coordinates ||= entry.location)} limit:1", width: '100%', height: '300' }
 
   = render_extensions :attrs_primary, folder: 'events'
 


### PR DESCRIPTION
If coordinates are not present, location is used.
Use URI::encode instead of silly replace to
URLencode search string for map.search.ch